### PR TITLE
Add special page alias

### DIFF
--- a/MultiPurge.alias.php
+++ b/MultiPurge.alias.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Aliases for MultiPurge
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+$specialPageAliases = [];
+
+/** English (English) */
+$specialPageAliases['en'] = [
+	'PurgeResources' => [ 'PurgeResources' ],
+];

--- a/extension.json
+++ b/extension.json
@@ -51,6 +51,9 @@
 			"i18n"
 		]
 	},
+	"ExtensionMessagesFiles": {
+		"MultiPurgeAlias": "MultiPurge.alias.php"
+	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\MultiPurge\\": "includes/"
 	},


### PR DESCRIPTION
This is the most basic version of the alias file needed to get rid of this notice on `Special:SpecialPages`:
> Notice: Did not find alias for special page 'PurgeResources'. Perhaps no aliases are defined for it? [Called from MediaWiki\SpecialPage\SpecialPageFactory::getLocalNameFor in /var/www/html/includes/specialpage/SpecialPageFactory.php at line 1552] in /var/www/html/includes/debug/MWDebug.php on line 507

![Screenshot_20221228_122818](https://user-images.githubusercontent.com/1428594/209798104-5119afc1-2444-489e-91e2-ebaa0cd32396.png)

This shouldn't do anything new besides just defining the original alias.