### PR TITLE
Add support for CloudFlare's cache by device type

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -23,6 +23,10 @@
 			"description": "",
 			"value": null
 		},
+		"MultiPurgeCloudFlareCacheByDeviceType": {
+			"description": "Whether or not CloudFlare's cache by device type is enabled.",
+			"value": false
+		},
 		"MultiPurgeVarnishServers": {
 			"description": "",
 			"value": null

--- a/includes/Services/Cloudflare.php
+++ b/includes/Services/Cloudflare.php
@@ -73,6 +73,19 @@ class Cloudflare implements PurgeServiceInterface {
 			sprintf( 'Added %d files to Cloudflare request: %s', count( $urls ), json_encode( $urls, JSON_THROW_ON_ERROR ) )
 		);
 
+		$postData = [ 'files' => $urls ];
+
+		if ( $this->extensionConfig->get( 'MultiPurgeCloudFlareCacheByDeviceType' ) ) {
+			foreach ( $urls as $url ) {
+				$postData['files'][] = [
+					'url' => $url,
+					'headers' => [ 'CF-Device-Type' => 'mobile' ]
+				];
+			}
+		}
+
+		$postData = json_encode( $postData, JSON_THROW_ON_ERROR );
+
 		return [
 			'method' => 'POST',
 			'url' => "https://api.cloudflare.com/client/v4/zones/$zoneId/purge_cache",
@@ -83,9 +96,9 @@ class Cloudflare implements PurgeServiceInterface {
 				'Authorization' => sprintf( 'Bearer %s', $apiToken ),
 				'Content-Type' => 'application/json',
 			],
-			'postData' => json_encode( [ 'files' => $urls ], JSON_THROW_ON_ERROR ),
+			'postData' => $postData,
 			// Body in case of curl
-			'body' => json_encode( [ 'files' => $urls ], JSON_THROW_ON_ERROR ),
+			'body' => $postData,
 		];
 	}
 }

--- a/includes/Services/Cloudflare.php
+++ b/includes/Services/Cloudflare.php
@@ -46,7 +46,9 @@ class Cloudflare implements PurgeServiceInterface {
 
 		$requests = [];
 
-		foreach ( array_chunk( $urls, 30 ) as $chunk ) {
+		$chunkSize = $this->extensionConfig->get( 'MultiPurgeCloudFlareCacheByDeviceType' ) ? 15 : 30;
+		
+		foreach ( array_chunk( $urls, $chunkSize ) as $chunk ) {
 			try {
 				$requests[] = $this->makeRequest( $chunk );
 			} catch ( JsonException $e ) {


### PR DESCRIPTION
If this setting is enabled in CloudFlare and the CF-Device-Type is not included, only cache for desktop devices will be cleared.